### PR TITLE
stacking tracing options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,6 @@
 ## chrome-timeline
 
 Write performance tests and get the timeline profiling data from puppeteer (chromium).
-The profiling data gets written to a folder `timeline` in the app path.
 
 ### Example:
 ```js
@@ -11,19 +10,86 @@ timeline(async (runner) => {
   // load something in chromium
   await runner.page.goto('https://example.com');
   // start a timeline profiling
-  await runner.tracingStart('LS_TRACE');
+  await runner.tracingStart('TRACE_ABC');
   // do something in the remote page
   await runner.remote((done, window) => {
     // this is within remote browser context
     some_heavy_stuff_to_be_measured();
-    // call done when finished
+    // call done when finished (sync variant)
     done();
+    // or async example with setTimeout
+    setTimeout(done, 10000);
   });
   // stop the profiling
   await runner.tracingStop();
 });
 ```
 
-### TODO:
+By default `timeline` does a clean startup of a remote puppeteer chromium client,
+runs the provided callback and exists the client afterwards.
+This behavior can be changed by providing custom options (e.g. connecting to a running remote instance).
+`timeline` returns a promise containing summaries of tracings that were done denoted
+by the name (`'TRACE_ABC'` in the example).
 
-- write viewer part for easier inspection (based on devtools app)
+### Tracing start default options
+```js
+tracingStartOptions: {
+  // path to trace file export (default: no file written)
+  path: null,
+  // whether the trace should contain screenshots
+  screenshots: true,
+  // profiling categories chrome understands
+  categories: [
+    '-*',
+    'v8.execute',
+    'blink.user_timing',
+    'latencyInfo',
+    'devtools.timeline',
+    'disabled-by-default-devtools.timeline',
+    'disabled-by-default-devtools.timeline.frame',
+    'toplevel',
+    'blink.console',
+    'disabled-by-default-devtools.timeline.stack',
+    'disabled-by-default-devtools.screenshot',
+    'disabled-by-default-v8.cpu_profile',
+    'disabled-by-default-v8.cpu_profiler',
+    'disabled-by-default-v8.cpu_profiler.hires'
+  ]
+}
+```
+
+### Tracing end default options
+```js
+tracingEndOptions: {
+  // save trace under timeline/<epoch>/runnerId_<epoch>.trace
+  saveTrace: false,
+  // create a summary of trace data, also saved if saveTrace=true
+  createSummary: true,
+  // report uncommitted changes for current git branch in summary
+  reportUncommittedChanges: false,
+}
+```
+
+### Summary
+
+Summaries are returned by `timeline` for a single tracing, if `tracingEndOptions.createSummary=true`.
+They contain various useful stats from a trace for further postprocessing:
+
+```js
+export interface ISummary extends IPostProcess {
+  // path to trace flie the summary belongs to (empty if tracingEndOptions.saveTrace=false)
+  traceFile: string;
+  // name of the trace as given to .tracingStart(name)
+  traceName: string;
+  // additional git repo stats (contains {isRepo: false} for non git repo projects)
+  repo: IRepoInfo;
+  // puppeteer profiling metadata (e.g. hardware setup, env data, cmdline)
+  metadata: {[key: string]: any};
+  // profiling summary as shown in the pie chart in devtools
+  summary: {[key: string]: number};
+  // top down tree events
+  topDown: IEvent[];
+  // bottom up tree events
+  bottomUp: IEvent[];
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export const DEFAULT_OPTIONS: ITimelineRunnerOptions = {
   connect: false,
   tracingStartOptions: {
     path: null,
-    screenshots: false,
+    screenshots: true,
     categories: [
       '-*',
       'v8.execute',
@@ -249,7 +249,7 @@ export class TimelineRunner {
       let summary: IPostProcess;
       if (opts.createSummary) {
         summary = postProcess(data);
-        summary['traceFile'] = tracePath;
+        summary['traceFile'] = (opts.saveTrace) ? tracePath : '';
         summary['traceName'] = traceName;
         summary['repo'] = await this.repoInfo(opts.reportUncommittedChanges);
         this.traceSummaries[traceName] = summary as ISummary;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -65,8 +65,8 @@ export interface ISummary extends IPostProcess {
 export interface ITracingEndOptions {
   /** save trace under timeline/<epoch>/runnerId_<epoch>.trace */
   saveTrace?: boolean;
-  /** create a summary of the trace data, aslo saved if saveTrace=true */
+  /** create a summary of the trace data, also saved if saveTrace=true */
   createSummary?: boolean;
-  /** report uncommitted changes for current git branchin summary */
+  /** report uncommitted changes for current git branch in summary */
   reportUncommittedChanges?: boolean;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,6 +23,7 @@ export interface ITimelineRunnerOptions {
   connectOptions?: p.ConnectOptions;
   connect?: boolean;
   tracingStartOptions?: p.TracingStartOptions;
+  tracingEndOptions?: ITracingEndOptions;  
   timeout?: number;
 }
 
@@ -35,21 +36,37 @@ export interface IRepoInfo {
 
 export interface IEvent {
   id: number;
-  name: string;
   parentId: number;
+  name: string;
   selfTime: number;
   totalTime: number;
 }
 
 export interface IPostProcess {
+  /** useful metadata created by puppeteer (contains hardware setup and such) */
   metadata: {[key: string]: any};
+  /** profiling summary as shown in the pie chart in devtools */
   summary: {[key: string]: number};
+  /** top down tree events */
   topDown: IEvent[];
+  /** bottom up tree events */
   bottomUp: IEvent[];
 }
 
 export interface ISummary extends IPostProcess {
+  /** path to trace the summary belongs to */
   traceFile: string;
+  /** name of the trace as given to .tracingStart(name) */
   traceName: string;
+  /** additional git repo stats */
   repo: IRepoInfo;
+}
+
+export interface ITracingEndOptions {
+  /** save trace under timeline/<epoch>/runnerId_<epoch>.trace */
+  saveTrace?: boolean;
+  /** create a summary of the trace data, aslo saved if saveTrace=true */
+  createSummary?: boolean;
+  /** report uncommitted changes for current git branchin summary */
+  reportUncommittedChanges?: boolean;
 }


### PR DESCRIPTION
More options for tracing / changes in behavior:
- `ITracingEndOptions`:
  - no trace saved by default, set with `saveTrace=true`
  - summary created by default, can be switched off by `createSummary=false`
  - uncommitted repo details are off by default, can be switched by `reportUncommittedChanges`
- tracing start and end options are stacking now